### PR TITLE
output printf() messages to the serial terminal on STM32

### DIFF
--- a/include/rtps/config_stm.h
+++ b/include/rtps/config_stm.h
@@ -31,6 +31,11 @@ namespace rtps {
 
 #define IS_LITTLE_ENDIAN 1
 
+/*
+ * Enabling this macro can output printf() to the serial terminal (via USART3).
+ * Note that linking printf() may increase the file size.
+ */
+//#define STM32_PRINTF_SERIAL
 
     namespace Config {
         const VendorId_t VENDOR_ID = {13, 37};

--- a/include/rtps/config_stm.h
+++ b/include/rtps/config_stm.h
@@ -34,7 +34,7 @@ namespace rtps {
 
     namespace Config {
         const VendorId_t VENDOR_ID = {13, 37};
-        const std::array<uint8_t, 4> IP_ADDRESS = {192,168,0,47};  // Needs to be set in lwipcfg.h too.
+        const std::array<uint8_t, 4> IP_ADDRESS = {192,168,0,47};  // Needs to be set in Src/lwip.c too.
         const GuidPrefix_t BASE_GUID_PREFIX{1,2,3,4,5,6,7,8,9,10,12};
 
         const uint8_t DOMAIN_ID = 0; // 230 possible with UDP

--- a/include/rtps/entities/StatefulReader.tpp
+++ b/include/rtps/entities/StatefulReader.tpp
@@ -73,7 +73,7 @@ void StatefulReaderT<NetworkDriver>::registerCallback(ddsReaderCallback_fp cb, v
         m_callback = cb;
         m_callee = callee; // It's okay if this is null
     }else{
-#if SLR_VERBOSE
+#if SFR_VERBOSE
         printf("StatefulReader[%s]: Passed callback is nullptr\n", &m_attributes.topicName[0]);
 #endif
     }

--- a/include/rtps/entities/StatefulWriter.tpp
+++ b/include/rtps/entities/StatefulWriter.tpp
@@ -61,7 +61,11 @@ template <class NetworkDriver>
 bool StatefulWriterT<NetworkDriver>::init(TopicData attributes, TopicKind_t topicKind, ThreadPool* /*threadPool*/, NetworkDriver& driver){
     if (sys_mutex_new(&m_mutex) != ERR_OK) {
 #if SFW_VERBOSE
+#ifndef STM32_PRINTF_SERIAL
         log("StatefulWriter: Failed to create mutex.\n");
+#else
+        printf("StatefulWriter: Failed to create mutex.\n");
+#endif
 #endif
         return false;
     }
@@ -84,9 +88,15 @@ bool StatefulWriterT<NetworkDriver>::init(TopicData attributes, TopicKind_t topi
 template <class NetworkDriver>
 bool StatefulWriterT<NetworkDriver>::addNewMatchedReader(const ReaderProxy& newProxy){
 #if SFW_VERBOSE
+#ifndef STM32_PRINTF_SERIAL
     log("StatefulWriter[%s]: New reader added with id: ", &this->m_attributes.topicName[0]);
     printGuid(newProxy.remoteReaderGuid);
     log("\n");
+#else
+    printf("StatefulWriter[%s]: New reader added with id: ", &this->m_attributes.topicName[0]);
+    printGuid(newProxy.remoteReaderGuid);
+    printf("\n");
+#endif
 #endif
     return m_proxies.add(newProxy);
 }
@@ -126,7 +136,11 @@ const rtps::CacheChange* StatefulWriterT<NetworkDriver>::newChange(ChangeKind_t 
     }
 
 #if SFW_VERBOSE
+#ifndef STM32_PRINTF_SERIAL
     log("StatefulWriter[%s]: Adding new data.\n", this->m_attributes.topicName);
+#else
+    printf("StatefulWriter[%s]: Adding new data.\n", this->m_attributes.topicName);
+#endif
 #endif
     return result;
 }
@@ -173,9 +187,15 @@ void StatefulWriterT<NetworkDriver>::onNewAckNack(const SubmessageAckNack& msg, 
 
     if(reader == nullptr){
 #if SFW_VERBOSE
+#ifndef STM32_PRINTF_SERIAL
         log("StatefulWriter[%s]: No proxy found with id: ", &this->m_attributes.topicName[0]);
         printEntityId(msg.readerId);
         log(" Dropping acknack.\n");
+#else
+        printf("StatefulWriter[%s]: No proxy found with id: ", &this->m_attributes.topicName[0]);
+        printEntityId(msg.readerId);
+        printf(" Dropping acknack.\n");
+#endif
 #endif
         return;
     }
@@ -194,7 +214,11 @@ void StatefulWriterT<NetworkDriver>::onNewAckNack(const SubmessageAckNack& msg, 
 
     if(msg.count.value <= reader->ackNackCount.value){
 #if SFW_VERBOSE
+#ifndef STM32_PRINTF_SERIAL
         log("StatefulWriter[%s]: Count too small. Dropping acknack.\n", &this->m_attributes.topicName[0]);
+#else
+        printf("StatefulWriter[%s]: Count too small. Dropping acknack.\n", &this->m_attributes.topicName[0]);
+#endif
 #endif
         return;
     }
@@ -205,15 +229,27 @@ void StatefulWriterT<NetworkDriver>::onNewAckNack(const SubmessageAckNack& msg, 
     SequenceNumber_t nextSN = msg.readerSNState.base;
 #if SFW_VERBOSE
     if(nextSN.low == 0 && nextSN.high == 0){
+#ifndef STM32_PRINTF_SERIAL
         log("StatefulWriter[%s]: Received preemptive acknack. Ignored.\n", &this->m_attributes.topicName[0]);
+#else
+        printf("StatefulWriter[%s]: Received preemptive acknack. Ignored.\n", &this->m_attributes.topicName[0]);
+#endif
     }else{
+#ifndef STM32_PRINTF_SERIAL
         log("StatefulWriter[%s]: Received non-preemptive acknack.\n", &this->m_attributes.topicName[0]);
+#else
+        printf("StatefulWriter[%s]: Received non-preemptive acknack.\n", &this->m_attributes.topicName[0]);
+#endif
     }
 #endif
     for(uint32_t i=0; i < msg.readerSNState.numBits; ++i, ++nextSN){
         if(msg.readerSNState.isSet(i)){
 #if SFW_VERBOSE
+#ifndef STM32_PRINTF_SERIAL
             log("StatefulWriter[%s]: Send Packet on acknack.\n", this->m_attributes.topicName);
+#else
+            printf("StatefulWriter[%s]: Send Packet on acknack.\n", this->m_attributes.topicName);
+#endif
 #endif
             sendData(*reader, nextSN);
         }
@@ -253,8 +289,13 @@ bool StatefulWriterT<NetworkDriver>::sendData(const ReaderProxy &reader, const S
         const CacheChange* next = m_history.getChangeBySN(snMissing);
         if(next == nullptr){
 #if SFW_VERBOSE
+#ifndef STM32_PRINTF_SERIAL
             log("StatefulWriter[%s]: Couldn't get a CacheChange with SN (%i,%u)\n", &this->m_attributes.topicName[0],
                                                                                        snMissing.high, snMissing.low);
+#else
+            printf("StatefulWriter[%s]: Couldn't get a CacheChange with SN (%i,%u)\n", &this->m_attributes.topicName[0],
+                                                                                       snMissing.high, snMissing.low);
+#endif
 #endif
             return false;
         }
@@ -284,7 +325,11 @@ template <class NetworkDriver>
 void StatefulWriterT<NetworkDriver>::sendHeartBeat() {
     if(m_proxies.isEmpty()){
 #if SFW_VERBOSE
+#ifndef STM32_PRINTF_SERIAL
         log("StatefulWriter[%s]: Skipping heartbeat. No proxies.\n", this->m_attributes.topicName);
+#else
+        printf("StatefulWriter[%s]: Skipping heartbeat. No proxies.\n", this->m_attributes.topicName);
+#endif
 #endif
         return;
     }
@@ -305,7 +350,11 @@ void StatefulWriterT<NetworkDriver>::sendHeartBeat() {
         if (firstSN == SEQUENCENUMBER_UNKNOWN || lastSN == SEQUENCENUMBER_UNKNOWN) {
 #if SFW_VERBOSE
             if(strlen(&this->m_attributes.typeName[0]) != 0){
+#ifndef STM32_PRINTF_SERIAL
                 log("StatefulWriter[%s]: Skipping heartbeat. No data.\n", this->m_attributes.topicName);
+#else
+                printf("StatefulWriter[%s]: Skipping heartbeat. No data.\n", this->m_attributes.topicName);
+#endif
             }
 #endif
             return;

--- a/src/discovery/SEDPAgent.cpp
+++ b/src/discovery/SEDPAgent.cpp
@@ -30,7 +30,7 @@ Author: i11 - Embedded Software, RWTH Aachen University
 #include "rtps/messages/MessageTypes.h"
 #include "ucdr/microcdr.h"
 
-#define SEDP_VERBOSE 1
+#define SEDP_VERBOSE 0
 
 using rtps::SEDPAgent;
 
@@ -121,7 +121,7 @@ void SEDPAgent::onNewPublisher(const TopicData& writerData) {
 		return;
 	}
 #if SEDP_VERBOSE
-    SEDP_LOG("PUB T/D %s/%s", writerData.topicName, writerData.typeName);
+    SEDP_LOG("PUB T/D %s/%s\n", writerData.topicName, writerData.typeName);
 #endif
 	Reader* reader = m_part->getMatchingReader(writerData);
     if(reader == nullptr){
@@ -173,7 +173,7 @@ void SEDPAgent::onNewSubscriber(const TopicData& readerData) {
 	}
     Writer* writer = m_part->getMatchingWriter(readerData);
 #if SEDP_VERBOSE
-    SEDP_LOG("SUB T/D %s/%s", readerData.topicName, readerData.typeName);
+    SEDP_LOG("SUB T/D %s/%s\n", readerData.topicName, readerData.typeName);
 #endif
     if(writer == nullptr) {
 #if SEDP_VERBOSE

--- a/src/discovery/SEDPAgent.cpp
+++ b/src/discovery/SEDPAgent.cpp
@@ -30,11 +30,12 @@ Author: i11 - Embedded Software, RWTH Aachen University
 #include "rtps/messages/MessageTypes.h"
 #include "ucdr/microcdr.h"
 
-#define SEDP_VERBOSE 0
+#define SEDP_VERBOSE 1
 
 using rtps::SEDPAgent;
 
 #if SEDP_VERBOSE
+#ifndef STM32_PRINTF_SERIAL
 uint32_t line_ = 0;
 char bf_[100];
 
@@ -47,6 +48,9 @@ char bf_[100];
 		line_ = (line_+1)%30; 							 \
 		}
 
+#else
+#define SEDP_LOG(...) printf(__VA_ARGS__)
+#endif
 #endif
 
 void SEDPAgent::init(Participant& part, const BuiltInEndpoints& endpoints){

--- a/src/entities/Domain.cpp
+++ b/src/entities/Domain.cpp
@@ -39,7 +39,7 @@ Domain::Domain() : m_threadPool(receiveJumppad, this), m_transport(ThreadPool::r
 bool Domain::completeInit(){
     m_initComplete = m_threadPool.startThreads();
 #if DOMAIN_VERBOSE
-    if(!started){
+    if(!m_initComplete){
         printf("Domain: Failed starting threads\n");
     }
 #endif

--- a/src/messages/MessageReceiver.cpp
+++ b/src/messages/MessageReceiver.cpp
@@ -130,7 +130,7 @@ bool MessageReceiver::processSubmessage(MessageProcessingInfo& msgInfo, const Su
             break;
         default:
 #if RECV_VERBOSE
-            printf("Submessage of type %u currently not supported. Skipping..\n", static_cast<uint8_t>(submsgHeader->submessageId));
+            printf("Submessage of type %u currently not supported. Skipping..\n", static_cast<uint8_t>(submsgHeader.submessageId));
 #endif
             success = false;
     }
@@ -158,7 +158,7 @@ bool MessageReceiver::processDataSubmessage(MessageProcessingInfo& msgInfo){
     }else{
 #if RECV_VERBOSE
         printf("Couldn't find a reader with id: ");
-        printEntityId(dataSubmsg->readerId);
+        printEntityId(dataSubmsg.readerId);
         printf("\n");
 #endif
     }


### PR DESCRIPTION
- 39d18c7bff86720a8c4114b8275ef2f2a67f6ef7 mod comment for the additional file name which IP address should be set
- ce73608333e0c46b21b3fac86865d02c3ec7f10e add `STM32_PRINTF_SERIAL` macro
  - Enabling this macro can output printf() to the serial terminal (via USART3).
  - Note that linking printf() may increase the file size. This macro is disabled by default.
- fix some bugs/typos when enabling *_VERBOSE macros
  - 4594d1dfc0f9ee3a4080fb40ea27c8b4a558390d
  - 74ef8cde5637b38ce015aefd982a30451768c1fc
  - 9af3ef9cadfeebd001937b28cb3081a3aa19511f
  - 644c87c8eb3f5412389e3fab8d755717d4a8fb5b
- 444035ebb98b65b7890411015e3221f213e1e809 use printf for SEDP_LOG on STM32

My modification to `include/rtps/entities/StatefulWriter.tpp` (be3c5e256d8cbe96852c3cc8ad7b7d4bff8918ba) may be the discussable point.
The original code uses `log()` to output the messages. I guess the implementation of `log()` is in progress. I didn't decide how to fix it, so I simply replace `log()` to printf() when `STM32_PRINTF_SERIAL` is defined.