### PR TITLE
replacing std::hash as it cannot operate on char[] with c++11

### DIFF
--- a/include/rtps/discovery/TopicData.h
+++ b/include/rtps/discovery/TopicData.h
@@ -29,10 +29,9 @@ Author: i11 - Embedded Software, RWTH Aachen University
 
 #include "rtps/common/Locator.h"
 #include "rtps/config.h"
+#include "rtps/utils/hash.h"
 #include "ucdr/microcdr.h"
 #include <array>
-#include <functional>
-#include <string>
 
 namespace rtps {
 
@@ -83,8 +82,8 @@ struct TopicDataCompressed {
   TopicDataCompressed() = default;
   TopicDataCompressed(const TopicData &topic_data) {
     endpointGuid = topic_data.endpointGuid;
-    topicHash = std::hash<std::string>{}(std::string(topic_data.topicName));
-    typeHash = std::hash<std::string>{}(std::string(topic_data.typeName));
+    topicHash = hashCharArray(topic_data.topicName, Config::MAX_TOPICNAME_LENGTH);
+    typeHash = hashCharArray(topic_data.typeName, Config::MAX_TYPENAME_LENGTH);
     reliabilityKind = topic_data.reliabilityKind;
     durabilityKind = topic_data.durabilityKind;
     unicastLocator = topic_data.unicastLocator;

--- a/include/rtps/utils/hash.h
+++ b/include/rtps/utils/hash.h
@@ -1,0 +1,39 @@
+/*
+The MIT License
+Copyright (c) 2019 Lehrstuhl Informatik 11 - RWTH Aachen University
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+This file is part of embeddedRTPS.
+
+Author: i11 - Embedded Software, RWTH Aachen University
+*/
+
+#ifndef RTPS_HASH_H
+#define RTPS_HASH_H
+
+namespace rtps {
+inline size_t hashCharArray(const char* p, size_t s){
+	 size_t result = 0;
+	 const size_t prime = 31;
+	 for (size_t i = 0; i < s; ++i) {
+	  result = p[i] + (result * prime);
+	 }
+	 return result;
+}
+}
+
+#endif

--- a/src/discovery/TopicData.cpp
+++ b/src/discovery/TopicData.cpp
@@ -188,6 +188,6 @@ bool TopicData::serializeIntoUcdrBuffer(ucdrBuffer &buffer) const {
 }
 
 bool TopicDataCompressed::matchesTopicOf(const TopicData &other) const {
-  return (std::hash<std::string>{}(std::string(other.topicName)) == topicHash &&
-          std::hash<std::string>{}(std::string(other.typeName)) == typeHash);
+  return (hashCharArray(other.topicName, sizeof(other.topicName)) == topicHash &&
+		  hashCharArray(other.typeName, sizeof(other.typeName)) == typeHash);
 }


### PR DESCRIPTION
the use of std::hash requires casting char[] to std::string, causing runtime memory allocation, replacing std::hash with https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function