### PR TITLE
remove extra token at end of #endif

### DIFF
--- a/src/entities/StatelessReader.cpp
+++ b/src/entities/StatelessReader.cpp
@@ -70,7 +70,7 @@ bool StatelessReader::addNewMatchedWriter(const WriterProxy &newProxy) {
   SLR_LOG("Adding WriterProxy");
   printGuid(newProxy.remoteWriterGuid);
   printf("\n");
-#endif SLR_VERBOSE
+#endif
   return m_proxies.add(newProxy);
 }
 


### PR DESCRIPTION
It involked a warning message when we use CMake environment.

```
./embeddedRTPS/src/entities/StatelessReader.cpp:73:8: warning: extra tokens at end of #endif directive [-Wendif-labels]
   73 | #endif SLR_VERBOSE
```