### PR TITLE
Deserialization failure returned incorrectly

### DIFF
--- a/include/rtps/storages/MemoryPool.h
+++ b/include/rtps/storages/MemoryPool.h
@@ -101,6 +101,7 @@ public:
 
   bool add(const TYPE &data) {
     if (isFull()) {
+      printf("[MemoryPool] RESSOURCE LIMIT EXCEEDED \n");
       return false;
     }
     for (uint8_t bucket = 0; bucket < sizeof(m_bitMap); ++bucket) {

--- a/src/discovery/ParticipantProxyData.cpp
+++ b/src/discovery/ParticipantProxyData.cpp
@@ -174,9 +174,9 @@ bool ParticipantProxyData::readLocatorIntoList(
           full_length_locator.isMulticastAddress()) {
         proxy_locator = LocatorIPv4(full_length_locator);
         SPDP_LOG("Adding locator: %u %u %u %u \n",
-                 (int)proxy_locator.address[12], (int)proxy_locator.address[13],
-                 (int)proxy_locator.address[14],
-                 (int)proxy_locator.address[15]);
+                 (int)proxy_locator.address[0], (int)proxy_locator.address[1],
+                 (int)proxy_locator.address[2],
+                 (int)proxy_locator.address[3]);
         return true;
       } else {
         SPDP_LOG("Ignoring locator: %u %u %u %u \n",
@@ -184,7 +184,7 @@ bool ParticipantProxyData::readLocatorIntoList(
                  (int)full_length_locator.address[13],
                  (int)full_length_locator.address[14],
                  (int)full_length_locator.address[15]);
-        return false;
+        return true;
       }
     } else {
       valid_locators++;

--- a/src/messages/MessageTypes.cpp
+++ b/src/messages/MessageTypes.cpp
@@ -166,11 +166,6 @@ bool rtps::deserializeMessage(const MessageProcessingInfo &info,
   }
 
   if (msg.readerSNState.numBits != 0) {
-    if (4 * ((msg.readerSNState.numBits / 32) + 1) >
-        msg.readerSNState.bitMap.size()) {
-      while (1)
-        ;
-    }
     doCopyAndMoveOn(
         reinterpret_cast<uint8_t *>(msg.readerSNState.bitMap.data()),
         currentPos, 4 * ((msg.readerSNState.numBits / 32) + 1));


### PR DESCRIPTION
If the first remote locator is not located on the embeddedRTPS subnet, an incorrect deserialization failure is returned, which breaks SPDP