### PR TITLE
Consistent Mutex Usage

### DIFF
--- a/include/rtps/discovery/SEDPAgent.h
+++ b/include/rtps/discovery/SEDPAgent.h
@@ -59,7 +59,7 @@ protected: // For testing purposes
 
 private:
   Participant *m_part;
-  sys_mutex_t m_mutex;
+  SemaphoreHandle_t m_mutex;
   uint8_t m_buffer[600]; // TODO check size, currently changed from 300 to 600
                          // (FastDDS gives too many options)
   BuiltInEndpoints m_endpoints;

--- a/include/rtps/discovery/SPDPAgent.h
+++ b/include/rtps/discovery/SPDPAgent.h
@@ -52,7 +52,6 @@ class ReaderCacheChange;
 
 class SPDPAgent {
 public:
-  ~SPDPAgent();
   void init(Participant &participant, BuiltInEndpoints &endpoints);
   void start();
   void stop();
@@ -67,7 +66,7 @@ private:
   ucdrBuffer m_microbuffer{};
   uint8_t m_cycleHB = 0;
 
-  sys_mutex_t m_mutex;
+  SemaphoreHandle_t m_mutex;
   bool initialized = false;
   static void receiveCallback(void *callee,
                               const ReaderCacheChange &cacheChange);

--- a/include/rtps/entities/Domain.h
+++ b/include/rtps/entities/Domain.h
@@ -84,7 +84,7 @@ private:
   }
 
   bool m_initComplete = false;
-  sys_mutex_t m_mutex;
+  SemaphoreHandle_t m_mutex;
 
   void receiveCallback(const PacketInfo &packet);
   GuidPrefix_t generateGuidPrefix(ParticipantId_t id) const;

--- a/include/rtps/entities/Participant.h
+++ b/include/rtps/entities/Participant.h
@@ -115,7 +115,7 @@ private:
   std::array<Reader *, Config::NUM_READERS_PER_PARTICIPANT> m_readers = {
       nullptr};
 
-  sys_mutex_t m_mutex;
+  SemaphoreHandle_t m_mutex;
   MemoryPool<ParticipantProxyData, Config::SPDP_MAX_NUMBER_FOUND_PARTICIPANTS>
       m_remoteParticipants;
 

--- a/include/rtps/entities/Reader.h
+++ b/include/rtps/entities/Reader.h
@@ -31,6 +31,7 @@ Author: i11 - Embedded Software, RWTH Aachen University
 #include "rtps/entities/WriterProxy.h"
 #include "rtps/storages/MemoryPool.h"
 #include "rtps/storages/PBufWrapper.h"
+#include "semphr.h"
 #include <cstring>
 
 namespace rtps {
@@ -135,10 +136,10 @@ protected:
   std::array<callbackElement_t, Config::MAX_NUM_READER_CALLBACKS> m_callbacks;
 
   // Guards manipulation of the proxies array
-  sys_mutex_t m_proxies_mutex = nullptr;
+  SemaphoreHandle_t m_proxies_mutex = nullptr;
 
   // Guards manipulation of callback array
-  sys_mutex_t m_callback_mutex = nullptr;
+  SemaphoreHandle_t m_callback_mutex = nullptr;
 };
 } // namespace rtps
 

--- a/include/rtps/entities/StatefulReader.tpp
+++ b/include/rtps/entities/StatefulReader.tpp
@@ -66,18 +66,16 @@ void StatefulReaderT<NetworkDriver>::newChange(
   if (m_callback_count == 0 || !m_is_initialized_) {
     return;
   }
-  sys_mutex_lock(&m_proxies_mutex);
+  Lock{m_proxies_mutex};
   for (auto &proxy : m_proxies) {
     if (proxy.remoteWriterGuid == cacheChange.writerGuid) {
       if (proxy.expectedSN == cacheChange.sn) {
-        sys_mutex_unlock(&m_proxies_mutex);
         executeCallbacks(cacheChange);
         ++proxy.expectedSN;
         return;
       }
     }
   }
-  sys_mutex_unlock(&m_proxies_mutex);
 }
 
 template <class NetworkDriver>

--- a/include/rtps/entities/StatelessWriter.tpp
+++ b/include/rtps/entities/StatelessWriter.tpp
@@ -67,7 +67,7 @@ bool StatelessWriterT<NetworkDriver>::init(TopicData attributes,
   m_attributes = attributes;
 
   if (m_mutex == nullptr) {
-    if (sys_mutex_new(&m_mutex) != ERR_OK) {
+    if (!createMutex(&m_mutex)) {
 #if SLW_VERBOSE
       SLW_LOG("Failed to create mutex \n");
 #endif

--- a/include/rtps/entities/Writer.h
+++ b/include/rtps/entities/Writer.h
@@ -82,7 +82,7 @@ public:
 protected:
   SequenceNumber_t m_sedp_sequence_number;
 
-  sys_mutex_t m_mutex = nullptr;
+  SemaphoreHandle_t m_mutex = nullptr;
   ThreadPool *mp_threadPool = nullptr;
 
   Ip4Port_t m_srcPort;

--- a/include/rtps/storages/ThreadSafeCircularBuffer.h
+++ b/include/rtps/storages/ThreadSafeCircularBuffer.h
@@ -26,6 +26,7 @@ Author: i11 - Embedded Software, RWTH Aachen University
 #define RTPS_THREADSAFEQUEUE_H
 
 #include "lwip/sys.h"
+#include "semphr.h"
 
 #include <array>
 #include <limits>
@@ -36,8 +37,6 @@ template <typename T, uint16_t SIZE> class ThreadSafeCircularBuffer {
 
 public:
   bool init();
-
-  ~ThreadSafeCircularBuffer();
 
   bool moveElementIntoBuffer(T &&elem);
 
@@ -57,7 +56,7 @@ private:
   static_assert(SIZE + 1 < std::numeric_limits<decltype(m_head)>::max(),
                 "Iterator is large enough for given size");
 
-  sys_mutex_t m_mutex;
+  SemaphoreHandle_t m_mutex;
   bool m_initialized = false;
 
   inline bool isFull();

--- a/include/rtps/storages/ThreadSafeCircularBuffer.tpp
+++ b/include/rtps/storages/ThreadSafeCircularBuffer.tpp
@@ -23,7 +23,7 @@ bool ThreadSafeCircularBuffer<T, SIZE>::init() {
   if (m_initialized) {
     return true;
   }
-  if (sys_mutex_new(&m_mutex) != ERR_OK) {
+  if (!createMutex(&m_mutex)) {
     TSCB_LOG("Failed to create mutex \n");
     return false;
   } else {
@@ -31,13 +31,6 @@ bool ThreadSafeCircularBuffer<T, SIZE>::init() {
              static_cast<void *>(&m_mutex));
     m_initialized = true;
     return true;
-  }
-}
-
-template <typename T, uint16_t SIZE>
-ThreadSafeCircularBuffer<T, SIZE>::~ThreadSafeCircularBuffer() {
-  if (m_initialized) {
-    sys_mutex_free(&m_mutex);
   }
 }
 

--- a/include/rtps/utils/Lock.h
+++ b/include/rtps/utils/Lock.h
@@ -27,22 +27,23 @@ Author: i11 - Embedded Software, RWTH Aachen University
 
 #include "FreeRTOS.h"
 #include "lwip/sys.h"
+#include "semphr.h"
 
 namespace rtps {
 
 class Lock {
 public:
-  explicit Lock(sys_mutex_t &passedMutex) : m_mutex(passedMutex) {
+  explicit Lock(SemaphoreHandle_t &mutex) : m_mutex(mutex) {
     xSemaphoreTakeRecursive(m_mutex, portMAX_DELAY);
   };
 
   ~Lock() { xSemaphoreGiveRecursive(m_mutex); };
 
 private:
-  sys_mutex_t m_mutex;
+  SemaphoreHandle_t m_mutex;
 };
 
-bool createMutex(sys_mutex_t *mutex);
+bool createMutex(SemaphoreHandle_t *mutex);
 
 } // namespace rtps
 #endif // RTPS_LOCK_H

--- a/src/discovery/SPDPAgent.cpp
+++ b/src/discovery/SPDPAgent.cpp
@@ -36,14 +36,8 @@ using rtps::SPDPAgent;
 using rtps::SMElement::BuildInEndpointSet;
 using rtps::SMElement::ParameterId;
 
-SPDPAgent::~SPDPAgent() {
-  if (initialized) {
-    sys_mutex_free(&m_mutex);
-  }
-}
-
 void SPDPAgent::init(Participant &participant, BuiltInEndpoints &endpoints) {
-  if (sys_mutex_new(&m_mutex) != ERR_OK) {
+  if (!createMutex(&m_mutex)) {
     SPDP_LOG("Could not alloc mutex");
     return;
   }

--- a/src/entities/Domain.cpp
+++ b/src/entities/Domain.cpp
@@ -45,7 +45,7 @@ Domain::Domain()
   m_transport.createUdpConnection(getUserMulticastPort());
   m_transport.createUdpConnection(getBuiltInMulticastPort());
   m_transport.joinMultiCastGroup(transformIP4ToU32(239, 255, 0, 1));
-  sys_mutex_new(&m_mutex);
+  createMutex(&m_mutex);
 }
 
 Domain::~Domain() { stop(); }

--- a/src/entities/Participant.cpp
+++ b/src/entities/Participant.cpp
@@ -53,7 +53,7 @@ Participant::Participant(const GuidPrefix_t &guidPrefix,
                          ParticipantId_t participantId)
     : m_guidPrefix(guidPrefix), m_participantId(participantId),
       m_receiver(this) {
-  if (sys_mutex_new(&m_mutex) != ERR_OK) {
+  if (!createMutex(&m_mutex)) {
     while (1)
       ;
   }

--- a/src/entities/Reader.cpp
+++ b/src/entities/Reader.cpp
@@ -18,14 +18,14 @@ void Reader::executeCallbacks(const ReaderCacheChange &cacheChange) {
 
 bool Reader::initMutex() {
   if (m_proxies_mutex == nullptr) {
-    if (sys_mutex_new(&m_proxies_mutex) != ERR_OK) {
+    if (!createMutex(&m_proxies_mutex)) {
       SFR_LOG("StatefulReader: Failed to create mutex.\n");
       return false;
     }
   }
 
   if (m_callback_mutex == nullptr) {
-    if (sys_mutex_new(&m_callback_mutex) != ERR_OK) {
+    if (!createMutex(&m_callback_mutex)) {
       SFR_LOG("StatefulReader: Failed to create mutex.\n");
       return false;
     }

--- a/src/utils/Lock.cpp
+++ b/src/utils/Lock.cpp
@@ -2,7 +2,7 @@
 
 namespace rtps {
 
-bool createMutex(sys_mutex_t *mutex) {
+bool createMutex(SemaphoreHandle_t *mutex) {
   *mutex = xSemaphoreCreateRecursiveMutex();
   if (*mutex != NULL) {
     return true;


### PR DESCRIPTION
This commit replaces calls to sys_mutex_* and replaces them with direct calls to FreeRTOS API. The reason behind this change is that some lwip abstraction layers use recursive mutexes, and others do not. embeddedRTPS gets stuck if non-recursive mutexes are used.