### PR TITLE
avoiding checking if sys_thread_t typed variables are nullptr

### DIFF
--- a/include/rtps/entities/StatefulWriter.h
+++ b/include/rtps/entities/StatefulWriter.h
@@ -56,7 +56,8 @@ private:
   NetworkDriver *m_transport;
 
   HistoryCacheWithDeletion<Config::HISTORY_SIZE_STATEFUL> m_history;
-  sys_thread_t m_heartbeatThread = nullptr;
+  sys_thread_t m_heartbeatThread;
+
   Count_t m_hbCount{1};
 
   bool m_running = true;

--- a/include/rtps/entities/StatefulWriter.tpp
+++ b/include/rtps/entities/StatefulWriter.tpp
@@ -88,7 +88,7 @@ bool StatefulWriterT<NetworkDriver>::init(TopicData attributes,
   // Thread already exists, do not create new one (reusing slot case)
   m_is_initialized_ = true;
 
-  if (m_heartbeatThread == nullptr || !m_thread_running) {
+  if (!m_thread_running) {
 
     m_running = true;
     m_thread_running = false;


### PR DESCRIPTION
... as it does not make sense for all lwip sys implementations.