### PR TITLE
Logging compilation errors and bugs

### DIFF
--- a/include/rtps/discovery/SPDPAgent.h
+++ b/include/rtps/discovery/SPDPAgent.h
@@ -30,6 +30,7 @@ Author: i11 - Embedded Software, RWTH Aachen University
 #include "rtps/config.h"
 #include "rtps/discovery/BuiltInEndpoints.h"
 #include "rtps/discovery/ParticipantProxyData.h"
+#include "rtps/utils/Log.h"
 #include "ucdr/microcdr.h"
 
 #if SPDP_VERBOSE && RTPS_GLOBAL_VERBOSE

--- a/include/rtps/entities/StatefulReader.tpp
+++ b/include/rtps/entities/StatefulReader.tpp
@@ -200,5 +200,3 @@ bool StatefulReaderT<NetworkDriver>::onNewHeartbeat(
   m_transport->sendPacket(info);
   return true;
 }
-
-#undef SFR_VERBOSE

--- a/include/rtps/entities/StatefulReader.tpp
+++ b/include/rtps/entities/StatefulReader.tpp
@@ -27,6 +27,7 @@ Author: i11 - Embedded Software, RWTH Aachen University
 #include "rtps/entities/StatefulReader.h"
 #include "rtps/messages/MessageFactory.h"
 #include "rtps/utils/Lock.h"
+#include "rtps/utils/Log.h"
 
 #if SFR_VERBOSE && RTPS_GLOBAL_VERBOSE
 #include "rtps/utils/printutils.h"

--- a/include/rtps/entities/StatefulWriter.tpp
+++ b/include/rtps/entities/StatefulWriter.tpp
@@ -179,7 +179,7 @@ template <class NetworkDriver> void StatefulWriterT<NetworkDriver>::progress() {
     }
   } else {
     SFW_LOG("Couldn't get a CacheChange with SN (%i,%u)\n",
-        m_nextSequenceNumberToSend.high, m_nextSequenceNumberToSend.low);
+            m_nextSequenceNumberToSend.high, m_nextSequenceNumberToSend.low);
   }
 
   ++m_nextSequenceNumberToSend;

--- a/include/rtps/entities/StatefulWriter.tpp
+++ b/include/rtps/entities/StatefulWriter.tpp
@@ -439,5 +439,3 @@ void StatefulWriterT<NetworkDriver>::sendHeartBeat() {
   }
   m_hbCount.value++;
 }
-
-#undef SFW_VERBOSE

--- a/include/rtps/entities/StatefulWriter.tpp
+++ b/include/rtps/entities/StatefulWriter.tpp
@@ -178,8 +178,8 @@ template <class NetworkDriver> void StatefulWriterT<NetworkDriver>::progress() {
       m_history.dropChange(next->sequenceNumber);
     }
   } else {
-    SFW_LOG("Couldn't get a CacheChange with SN (%i,%u)\n", snMissing.high,
-            snMissing.low);
+    SFW_LOG("Couldn't get a CacheChange with SN (%i,%u)\n",
+        m_nextSequenceNumberToSend.high, m_nextSequenceNumberToSend.low);
   }
 
   ++m_nextSequenceNumberToSend;

--- a/include/rtps/utils/Log.h
+++ b/include/rtps/utils/Log.h
@@ -42,5 +42,6 @@ Author: i11 - Embedded Software, RWTH Aachen University
 #define SLW_VERBOSE 0
 #define SFR_VERBOSE 0
 #define SLR_VERBOSE 0
+#define THREAD_POOL_VERBOSE 0
 
 #endif // RTPS_LOG_H

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -31,14 +31,14 @@ Author: i11 - Embedded Software, RWTH Aachen University
 
 using rtps::ThreadPool;
 
-#define THREAD_POOL_VERBOSE 0
 #if THREAD_POOL_VERBOSE && RTPS_GLOBAL_VERBOSE
-#define THREAD_POOL_LOG(...)
-if (true) {
-  printf("[ThreadPool] ");
-  printf(__VA_ARGS__);
-  printf("\n");
-}
+#include "rtps/utils/printutils.h"
+#define THREAD_POOL_LOG(...)                                                   \
+  if (true) {                                                                  \
+    printf("[ThreadPool] ");                                                   \
+    printf(__VA_ARGS__);                                                       \
+    printf("\n");                                                              \
+  }
 #else
 #define THREAD_POOL_LOG(...) //
 #endif

--- a/src/discovery/SEDPAgent.cpp
+++ b/src/discovery/SEDPAgent.cpp
@@ -123,8 +123,8 @@ void SEDPAgent::addUnmatchedRemoteWriter(
 #endif
     return;
   }
-  SEDP_LOG("Adding unmatched remote writer %s %s.\n", writerData.topicName,
-           writerData.typeName);
+  SEDP_LOG("Adding unmatched remote writer %zx %zx.\n", writerData.topicHash,
+           writerData.typeHash);
   m_unmatchedRemoteWriters.add(writerData);
 }
 
@@ -136,8 +136,8 @@ void SEDPAgent::addUnmatchedRemoteReader(
 #endif
     return;
   }
-  SEDP_LOG("Adding unmatched remote reader %s %s.\n", readerData.topicName,
-           readerData.typeName);
+  SEDP_LOG("Adding unmatched remote reader %zx %zx.\n", readerData.topicHash,
+           readerData.typeHash);
   m_unmatchedRemoteReaders.add(readerData);
 }
 

--- a/src/discovery/TopicData.cpp
+++ b/src/discovery/TopicData.cpp
@@ -24,6 +24,7 @@ Author: i11 - Embedded Software, RWTH Aachen University
 #include "rtps/discovery/TopicData.h"
 #include "rtps/messages/MessageTypes.h"
 #include <cstring>
+#include <cstdio>
 
 using rtps::TopicData;
 using rtps::TopicDataCompressed;

--- a/src/discovery/TopicData.cpp
+++ b/src/discovery/TopicData.cpp
@@ -23,8 +23,8 @@ Author: i11 - Embedded Software, RWTH Aachen University
 */
 #include "rtps/discovery/TopicData.h"
 #include "rtps/messages/MessageTypes.h"
-#include <cstring>
 #include <cstdio>
+#include <cstring>
 
 using rtps::TopicData;
 using rtps::TopicDataCompressed;

--- a/src/entities/Reader.cpp
+++ b/src/entities/Reader.cpp
@@ -2,6 +2,7 @@
 #include <rtps/entities/StatefulReader.h>
 #include <rtps/entities/StatelessReader.h>
 #include <rtps/utils/Lock.h>
+#include <rtps/utils/Log.h>
 
 using namespace rtps;
 

--- a/src/entities/Writer.cpp
+++ b/src/entities/Writer.cpp
@@ -1,7 +1,9 @@
 #include <rtps/config.h>
+#include <rtps/entities/StatefulWriter.h>
 #include <rtps/entities/ReaderProxy.h>
 #include <rtps/entities/Writer.h>
 #include <rtps/storages/MemoryPool.h>
+#include "rtps/utils/Log.h"
 
 using namespace rtps;
 

--- a/src/entities/Writer.cpp
+++ b/src/entities/Writer.cpp
@@ -1,9 +1,9 @@
+#include "rtps/utils/Log.h"
 #include <rtps/config.h>
-#include <rtps/entities/StatefulWriter.h>
 #include <rtps/entities/ReaderProxy.h>
+#include <rtps/entities/StatefulWriter.h>
 #include <rtps/entities/Writer.h>
 #include <rtps/storages/MemoryPool.h>
-#include "rtps/utils/Log.h"
 
 using namespace rtps;
 


### PR DESCRIPTION
- Add missing backslashes to `THREAD_POOL_LOG`
- Move `THREAD_POOL_VERBOSE` to the other verbose-defines in Log.h
- Fix variable name in `StatefulWriterT<...>::progress`
- Fix variable name and type in `SEDPAgent::addUnmatchedRemoteWriter/Reader`
- Make sure Log.h is included whenever `RTPS_GLOBAL_VERBOSE` is used
- Make sure cstdio is included whenever `printf` is used directly
- Make sure StatefulWriter.h is included when `SFW_LOG` is used in Writer.cpp, and at the end of StatefulWriter.tpp, `SFW_VERBOSE` may not be `#undef`'ed because it is used in Writer.cpp