### PR TITLE
Fix IP address multicast check

### DIFF
--- a/include/rtps/utils/udpUtils.h
+++ b/include/rtps/utils/udpUtils.h
@@ -41,8 +41,7 @@ const uint16_t D3 = 11; // User unicast
 
 constexpr ip4_addr transformIP4ToU32(uint8_t MSB, uint8_t p2, uint8_t p1,
                                      uint8_t LSB) {
-  return {((uint32_t)(LSB << 24)) | ((uint32_t)(p1 << 16)) |
-          ((uint32_t)(p2 << 8)) | MSB};
+  return ip4_addr{PP_HTONL(LWIP_MAKEU32(MSB, p2, p1, LSB))};
 }
 
 constexpr Ip4Port_t getBuiltInUnicastPort(ParticipantId_t participantId) {

--- a/src/communication/UdpDriver.cpp
+++ b/src/communication/UdpDriver.cpp
@@ -88,7 +88,7 @@ bool UdpDriver::isSameSubnet(ip4_addr_t addr) {
 }
 
 bool UdpDriver::isMulticastAddress(ip4_addr_t addr) {
-  return ((addr.addr >> 28) == 14);
+  return ((addr.addr & 0xF0) == 0xE0);
 }
 
 bool UdpDriver::joinMultiCastGroup(ip4_addr_t addr) const {

--- a/src/communication/UdpDriver.cpp
+++ b/src/communication/UdpDriver.cpp
@@ -88,7 +88,11 @@ bool UdpDriver::isSameSubnet(ip4_addr_t addr) {
 }
 
 bool UdpDriver::isMulticastAddress(ip4_addr_t addr) {
-  return ((addr.addr & 0xF0) == 0xE0);
+#if IS_LITTLE_ENDIAN
+  return (addr.addr & 0xF0) == 0xE0;
+#else
+  return (addr.addr >> 28) == 14;
+#endif
 }
 
 bool UdpDriver::joinMultiCastGroup(ip4_addr_t addr) const {

--- a/src/discovery/ParticipantProxyData.cpp
+++ b/src/discovery/ParticipantProxyData.cpp
@@ -170,8 +170,8 @@ bool ParticipantProxyData::readLocatorIntoList(
   for (auto &proxy_locator : list) {
     if (!proxy_locator.isValid()) {
       bool ret = full_length_locator.readFromUcdrBuffer(buffer);
-      if ((ret && full_length_locator.isSameSubnet()) ||
-          full_length_locator.isMulticastAddress()) {
+      if (ret && (full_length_locator.isSameSubnet() ||
+          full_length_locator.isMulticastAddress())) {
         proxy_locator = LocatorIPv4(full_length_locator);
         SPDP_LOG("Adding locator: %u %u %u %u \n",
                  (int)proxy_locator.address[0], (int)proxy_locator.address[1],

--- a/src/discovery/ParticipantProxyData.cpp
+++ b/src/discovery/ParticipantProxyData.cpp
@@ -171,7 +171,7 @@ bool ParticipantProxyData::readLocatorIntoList(
     if (!proxy_locator.isValid()) {
       bool ret = full_length_locator.readFromUcdrBuffer(buffer);
       if (ret && (full_length_locator.isSameSubnet() ||
-          full_length_locator.isMulticastAddress())) {
+                  full_length_locator.isMulticastAddress())) {
         proxy_locator = LocatorIPv4(full_length_locator);
         SPDP_LOG("Adding locator: %u %u %u %u \n",
                  (int)proxy_locator.address[0], (int)proxy_locator.address[1],


### PR DESCRIPTION
`isMulticastAddress` used to read the octet at the wrong end of the given IP address to check if it is a multicast address, on both little and big endian systems. By `transformIP4ToU32` always producing a big endian number and `isMulticastAddress` always expecting one, it works now on both systems.

Also, only test this if `readFromUcdrBuffer` succeeds.