### PR TITLE
fix: make locks not unlock immediately

### DIFF
--- a/include/rtps/entities/StatefulReader.tpp
+++ b/include/rtps/entities/StatefulReader.tpp
@@ -68,7 +68,7 @@ void StatefulReaderT<NetworkDriver>::newChange(
   if (m_callback_count == 0 || !m_is_initialized_) {
     return;
   }
-  Lock{m_proxies_mutex};
+  Lock lock{m_proxies_mutex};
   for (auto &proxy : m_proxies) {
     if (proxy.remoteWriterGuid == cacheChange.writerGuid) {
       if (proxy.expectedSN == cacheChange.sn) {
@@ -112,7 +112,7 @@ bool StatefulReaderT<NetworkDriver>::addNewMatchedWriter(
 template <class NetworkDriver>
 bool StatefulReaderT<NetworkDriver>::onNewGapMessage(
     const SubmessageGap &msg, const GuidPrefix_t &remotePrefix) {
-  Lock lock(m_proxies_mutex);
+  Lock lock{m_proxies_mutex};
   if (!m_is_initialized_) {
     return false;
   }
@@ -209,7 +209,7 @@ bool StatefulReaderT<NetworkDriver>::onNewGapMessage(
 template <class NetworkDriver>
 bool StatefulReaderT<NetworkDriver>::onNewHeartbeat(
     const SubmessageHeartbeat &msg, const GuidPrefix_t &sourceGuidPrefix) {
-  Lock lock(m_proxies_mutex);
+  Lock lock{m_proxies_mutex};
   if (!m_is_initialized_) {
     return false;
   }
@@ -257,7 +257,7 @@ bool StatefulReaderT<NetworkDriver>::onNewHeartbeat(
 template <class NetworkDriver>
 bool StatefulReaderT<NetworkDriver>::sendPreemptiveAckNack(
     const WriterProxy &writer) {
-  Lock lock(m_proxies_mutex);
+  Lock lock{m_proxies_mutex};
   if (!m_is_initialized_) {
     return false;
   }

--- a/include/rtps/entities/StatefulWriter.tpp
+++ b/include/rtps/entities/StatefulWriter.tpp
@@ -159,7 +159,7 @@ const rtps::CacheChange *StatefulWriterT<NetworkDriver>::newChange(
 
 template <class NetworkDriver> void StatefulWriterT<NetworkDriver>::progress() {
   INIT_GUARD()
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   CacheChange *next = m_history.getChangeBySN(m_nextSequenceNumberToSend);
   if (next != nullptr) {
     uint32_t i = 0;
@@ -210,7 +210,7 @@ template <class NetworkDriver> void StatefulWriterT<NetworkDriver>::progress() {
 template <class NetworkDriver>
 void StatefulWriterT<NetworkDriver>::setAllChangesToUnsent() {
   INIT_GUARD()
-  Lock lock(m_mutex);
+  Lock lock{m_mutex};
 
   m_nextSequenceNumberToSend = m_history.getCurrentSeqNumMin();
 
@@ -223,7 +223,7 @@ template <class NetworkDriver>
 void StatefulWriterT<NetworkDriver>::onNewAckNack(
     const SubmessageAckNack &msg, const GuidPrefix_t &sourceGuidPrefix) {
   INIT_GUARD()
-  Lock lock(m_mutex);
+  Lock lock{m_mutex};
   if (!m_is_initialized_) {
     return;
   }
@@ -512,7 +512,7 @@ void StatefulWriterT<NetworkDriver>::sendHeartBeat() {
     MessageFactory::addHeader(info.buffer, m_attributes.endpointGuid.prefix);
 
     {
-      Lock lock(m_mutex);
+      Lock lock{m_mutex};
 
       if (!m_history.isEmpty()) {
         firstSN = m_history.getCurrentSeqNumMin();

--- a/src/discovery/SEDPAgent.cpp
+++ b/src/discovery/SEDPAgent.cpp
@@ -156,7 +156,7 @@ void SEDPAgent::removeUnmatchedEntity(const Guid_t &guid) {
 
 void SEDPAgent::removeUnmatchedEntitiesOfParticipant(
     const GuidPrefix_t &guidPrefix) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   auto isElementToRemove = [&](const TopicDataCompressed &topicData) {
     return topicData.endpointGuid.prefix == guidPrefix;
   };

--- a/src/entities/Domain.cpp
+++ b/src/entities/Domain.cpp
@@ -240,7 +240,7 @@ void Domain::registerMulticastPort(FullLengthLocator mcastLocator) {
 
 rtps::Reader *Domain::readerExists(Participant &part, const char *topicName,
                                    const char *typeName, bool reliable) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   if (reliable) {
     for (unsigned int i = 0; i < m_statefulReaders.size(); i++) {
       if (m_statefulReaders[i].isInitialized()) {
@@ -285,7 +285,7 @@ rtps::Reader *Domain::readerExists(Participant &part, const char *topicName,
 
 rtps::Writer *Domain::writerExists(Participant &part, const char *topicName,
                                    const char *typeName, bool reliable) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   if (reliable) {
     for (unsigned int i = 0; i < m_statefulWriters.size(); i++) {
       if (m_statefulWriters[i].isInitialized()) {
@@ -330,7 +330,7 @@ rtps::Writer *Domain::writerExists(Participant &part, const char *topicName,
 rtps::Writer *Domain::createWriter(Participant &part, const char *topicName,
                                    const char *typeName, bool reliable,
                                    bool enforceUnicast) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   StatelessWriter *statelessWriter =
       getNextUnusedEndpoint<decltype(m_statelessWriters), StatelessWriter>(
           m_statelessWriters);
@@ -391,7 +391,7 @@ rtps::Writer *Domain::createWriter(Participant &part, const char *topicName,
 rtps::Reader *Domain::createReader(Participant &part, const char *topicName,
                                    const char *typeName, bool reliable,
                                    ip4_addr_t mcastaddress) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   StatelessReader *statelessReader =
       getNextUnusedEndpoint<decltype(m_statelessReaders), StatelessReader>(
           m_statelessReaders);
@@ -468,7 +468,7 @@ rtps::Reader *Domain::createReader(Participant &part, const char *topicName,
 }
 
 bool rtps::Domain::deleteReader(Participant &part, Reader *reader) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   if(reader == nullptr || !reader->isInitialized()){
 	  return false;
   }
@@ -481,7 +481,7 @@ bool rtps::Domain::deleteReader(Participant &part, Reader *reader) {
 }
 
 bool rtps::Domain::deleteWriter(Participant &part, Writer *writer) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   if(writer == nullptr || !writer->isInitialized()){
 	  return false;
   }

--- a/src/entities/Participant.cpp
+++ b/src/entities/Participant.cpp
@@ -105,7 +105,7 @@ bool Participant::registerOnNewSubscriberMatchedCallback(
 }
 
 rtps::Writer *Participant::addWriter(Writer *pWriter) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (unsigned int i = 0; i < m_writers.size(); i++) {
     if (m_writers[i] == nullptr) {
       m_writers[i] = pWriter;
@@ -119,7 +119,7 @@ rtps::Writer *Participant::addWriter(Writer *pWriter) {
 }
 
 bool Participant::isWritersFull() {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (unsigned int i = 0; i < m_writers.size(); i++) {
     if (m_writers[i] == nullptr) {
       return false;
@@ -130,7 +130,7 @@ bool Participant::isWritersFull() {
 }
 
 rtps::Reader *Participant::addReader(Reader *pReader) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (unsigned int i = 0; i < m_readers.size(); i++) {
     if (m_readers[i] == nullptr) {
       m_readers[i] = pReader;
@@ -145,7 +145,7 @@ rtps::Reader *Participant::addReader(Reader *pReader) {
 }
 
 bool Participant::deleteReader(Reader *reader) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (unsigned int i = 0; i < m_readers.size(); i++) {
     if (m_readers[i]->getSEDPSequenceNumber() ==
         reader->getSEDPSequenceNumber()) {
@@ -160,7 +160,7 @@ bool Participant::deleteReader(Reader *reader) {
 }
 
 bool Participant::deleteWriter(Writer *writer) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (unsigned int i = 0; i < m_writers.size(); i++) {
     if (m_writers[i]->getSEDPSequenceNumber() ==
         writer->getSEDPSequenceNumber()) {
@@ -175,7 +175,7 @@ bool Participant::deleteWriter(Writer *writer) {
 }
 
 bool Participant::isReadersFull() {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (unsigned int i = 0; i < m_readers.size(); i++) {
     if (m_readers[i] == nullptr) {
       return false;
@@ -186,7 +186,7 @@ bool Participant::isReadersFull() {
 }
 
 rtps::Writer *Participant::getWriter(EntityId_t id) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (uint8_t i = 0; i < m_writers.size(); ++i) {
     if (m_writers[i] == nullptr) {
       continue;
@@ -199,7 +199,7 @@ rtps::Writer *Participant::getWriter(EntityId_t id) {
 }
 
 rtps::Reader *Participant::getReader(EntityId_t id) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (uint8_t i = 0; i < m_readers.size(); ++i) {
     if (m_readers[i] == nullptr) {
       continue;
@@ -225,7 +225,7 @@ rtps::Reader *Participant::getReaderByWriterId(const Guid_t &guid) {
 }
 
 rtps::Writer *Participant::getMatchingWriter(const TopicData &readerTopicData) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (uint8_t i = 0; i < m_writers.size(); ++i) {
     if (m_writers[i] == nullptr) {
       continue;
@@ -241,7 +241,7 @@ rtps::Writer *Participant::getMatchingWriter(const TopicData &readerTopicData) {
 }
 
 rtps::Reader *Participant::getMatchingReader(const TopicData &writerTopicData) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (uint8_t i = 0; i < m_readers.size(); ++i) {
     if (m_readers[i] == nullptr) {
       continue;
@@ -258,7 +258,7 @@ rtps::Reader *Participant::getMatchingReader(const TopicData &writerTopicData) {
 
 rtps::Writer *
 Participant::getMatchingWriter(const TopicDataCompressed &readerTopicData) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (uint8_t i = 0; i < m_writers.size(); ++i) {
     if (m_writers[i] == nullptr) {
       continue;
@@ -275,7 +275,7 @@ Participant::getMatchingWriter(const TopicDataCompressed &readerTopicData) {
 
 rtps::Reader *
 Participant::getMatchingReader(const TopicDataCompressed &writerTopicData) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (uint8_t i = 0; i < m_readers.size(); ++i) {
     if (m_readers[i] == nullptr) {
       continue;
@@ -292,12 +292,12 @@ Participant::getMatchingReader(const TopicDataCompressed &writerTopicData) {
 
 bool Participant::addNewRemoteParticipant(
     const ParticipantProxyData &remotePart) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   return m_remoteParticipants.add(remotePart);
 }
 
 bool Participant::removeRemoteParticipant(const GuidPrefix_t &prefix) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   auto isElementToRemove = [&](const ParticipantProxyData &proxy) {
     return proxy.m_guid.prefix == prefix;
   };
@@ -310,7 +310,7 @@ bool Participant::removeRemoteParticipant(const GuidPrefix_t &prefix) {
 }
 
 void Participant::removeAllProxiesOfParticipant(const GuidPrefix_t &prefix) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (unsigned int i = 0; i < m_readers.size(); i++) {
     if (m_readers[i] == nullptr) {
       continue;
@@ -327,7 +327,7 @@ void Participant::removeAllProxiesOfParticipant(const GuidPrefix_t &prefix) {
 }
 
 void Participant::removeProxyFromAllEndpoints(const Guid_t &guid) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (unsigned int i = 0; i < m_writers.size(); i++) {
     if (m_writers[i] == nullptr) {
       continue;
@@ -355,7 +355,7 @@ void Participant::removeProxyFromAllEndpoints(const Guid_t &guid) {
 
 const rtps::ParticipantProxyData *
 Participant::findRemoteParticipant(const GuidPrefix_t &prefix) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   auto isElementToFind = [&](const ParticipantProxyData &proxy) {
     return proxy.m_guid.prefix == prefix;
   };
@@ -367,7 +367,7 @@ Participant::findRemoteParticipant(const GuidPrefix_t &prefix) {
 
 void Participant::refreshRemoteParticipantLiveliness(
     const GuidPrefix_t &prefix) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   auto isElementToFind = [&](const ParticipantProxyData &proxy) {
     return proxy.m_guid.prefix == prefix;
   };
@@ -382,7 +382,7 @@ void Participant::refreshRemoteParticipantLiveliness(
 }
 
 bool Participant::hasReaderWithMulticastLocator(ip4_addr_t address) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   for (uint8_t i = 0; i < m_readers.size(); i++) {
     if (m_readers[i] == nullptr) {
       continue;
@@ -395,15 +395,15 @@ bool Participant::hasReaderWithMulticastLocator(ip4_addr_t address) {
 }
 
 uint32_t Participant::getRemoteParticipantCount() {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   return m_remoteParticipants.getNumElements();
 }
 
 rtps::MessageReceiver *Participant::getMessageReceiver() { return &m_receiver; }
 
 bool Participant::checkAndResetHeartbeats() {
-  Lock{m_mutex};
-  Lock{m_spdpAgent.m_mutex};
+  Lock lock1{m_mutex};
+  Lock lock2{m_spdpAgent.m_mutex};
   PARTICIPANT_LOG("Have %u remote participants",
                   (unsigned int)m_remoteParticipants.getNumElements());
   PARTICIPANT_LOG(
@@ -521,7 +521,7 @@ void Participant::printInfo() {
 rtps::SPDPAgent &Participant::getSPDPAgent() { return m_spdpAgent; }
 
 void Participant::addBuiltInEndpoints(BuiltInEndpoints &endpoints) {
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   m_hasBuilInEndpoints = true;
   m_spdpAgent.init(*this, endpoints);
   m_sedpAgent.init(*this, endpoints);

--- a/src/entities/Writer.cpp
+++ b/src/entities/Writer.cpp
@@ -98,7 +98,7 @@ void rtps::Writer::manageSendOptions() {
 void rtps::Writer::removeAllProxiesOfParticipant(
     const GuidPrefix_t &guidPrefix) {
   INIT_GUARD();
-  Lock lock(m_mutex);
+  Lock lock{m_mutex};
   auto isElementToRemove = [&](const ReaderProxy &proxy) {
     return proxy.remoteReaderGuid.prefix == guidPrefix;
   };
@@ -138,7 +138,7 @@ int rtps::Writer::dumpAllProxies(dumpProxyCallback target, void *arg) {
   if (target == nullptr) {
     return 0;
   }
-  Lock{m_mutex};
+  Lock lock{m_mutex};
   int dump_count = 0;
   for (auto it = m_proxies.begin(); it != m_proxies.end(); ++it, ++dump_count) {
     target(this, *it, arg);


### PR DESCRIPTION
Just a drive-by fix. This replace temporaries with scope variables.