### PR TITLE
CacheChange assignment operator not returning itself.

### DIFF
--- a/include/rtps/storages/CacheChange.h
+++ b/include/rtps/storages/CacheChange.h
@@ -46,6 +46,7 @@ struct CacheChange {
 	  sentTickCount = other.sentTickCount;
 	  sequenceNumber = other.sequenceNumber;
 	  data = std::move(other.data);
+	  return *this;
   }
 
   CacheChange() = default;


### PR DESCRIPTION
Fixed warning:

lib/embeddedRTPS/include/rtps/storages/CacheChange.h: In member function 'rtps::CacheChange& rtps::CacheChange::operator=(rtps::CacheChange&&)':
lib/embeddedRTPS/include/rtps/storages/CacheChange.h:49:3: warning: no return statement in function returning non-void [-Wreturn-type]
   }