### PR TITLE
Fixed compilation warning of no return on non-void method.

### DIFF
--- a/include/rtps/entities/StatefulReader.tpp
+++ b/include/rtps/entities/StatefulReader.tpp
@@ -203,6 +203,7 @@ bool StatefulReaderT<NetworkDriver>::onNewGapMessage(
 	  }
 
 
+    return false;
   }
 }
 


### PR DESCRIPTION
Fixed warning:

lib/embeddedRTPS/include/rtps/entities/StatefulReader.tpp: In member function 'bool rtps::StatefulReaderT<NetworkDriver>::onNewGapMessage(const rtps::SubmessageGap&, const rtps::GuidPrefix_t&) [with NetworkDriver = rtps::UdpDriver]':
lib/embeddedRTPS/include/rtps/entities/StatefulReader.tpp:115:8: warning: control reaches end of non-void function [-Wreturn-type]